### PR TITLE
Add token diagnostics for Bruniai report uploads

### DIFF
--- a/packages/mcp-server/src/server-factory.ts
+++ b/packages/mcp-server/src/server-factory.ts
@@ -161,6 +161,24 @@ function buildErrorResponse(error: unknown) {
   };
 }
 
+function summarizeToken(token: string | undefined | null) {
+  const raw = token ?? "";
+  const trimmed = raw.trim();
+  const normalized = trimmed.replace(/^Bearer\s+/i, "");
+
+  return {
+    present: raw.length > 0,
+    length: raw.length,
+    trimmedLength: trimmed.length,
+    hasLeadingOrTrailingWhitespace: raw !== trimmed,
+    startsWithBearerPrefix: /^Bearer\s+/i.test(trimmed),
+    normalizedLength: normalized.length,
+    jwtSegmentCount: normalized ? normalized.split(".").length : 0,
+    prefix: normalized ? normalized.slice(0, 8) : "",
+    suffix: normalized ? normalized.slice(-6) : "",
+  };
+}
+
 async function tryGetReportUrl(
   comparisonService: ComparisonService,
   result: unknown,
@@ -172,6 +190,7 @@ async function tryGetReportUrl(
   repository?: string,
 ): Promise<string | null> {
   const bruniToken = process.env.BRUNI_TOKEN;
+  console.log("[MCP] Report token diagnostics:", summarizeToken(bruniToken));
   if (!bruniToken) {
     return null;
   }

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -1,5 +1,22 @@
 import type { MultiPageReportData } from "./types.js";
 
+function summarizeToken(token: string) {
+  const trimmed = token.trim();
+  const normalized = trimmed.replace(/^Bearer\s+/i, "");
+
+  return {
+    present: token.length > 0,
+    length: token.length,
+    trimmedLength: trimmed.length,
+    hasLeadingOrTrailingWhitespace: token !== trimmed,
+    startsWithBearerPrefix: /^Bearer\s+/i.test(trimmed),
+    normalizedLength: normalized.length,
+    jwtSegmentCount: normalized ? normalized.split(".").length : 0,
+    prefix: normalized ? normalized.slice(0, 8) : "",
+    suffix: normalized ? normalized.slice(-6) : "",
+  };
+}
+
 /**
  * BruniReporter class for sending multi-page reports to the Bruni API.
  */
@@ -17,6 +34,7 @@ export class BruniReporter {
     this.token = token;
     this.apiUrl = apiUrl;
     console.log(`Bruni reporter initialized with endpoint: ${apiUrl}`);
+    console.log("[BruniReporter] Token diagnostics:", summarizeToken(token));
   }
 
   /**
@@ -69,6 +87,16 @@ export class BruniReporter {
       }
 
       try {
+        console.log(
+          `[BruniReporter] POST ${this.apiUrl} chunk ${chunkIndex + 1}/${
+            chunks.length
+          } auth diagnostics:`,
+          {
+            authorizationMode: "Bearer <token>",
+            token: summarizeToken(this.token),
+          }
+        );
+
         const response = await fetch(this.apiUrl, {
           method: "POST",
           headers: {
@@ -83,6 +111,10 @@ export class BruniReporter {
 
         if (!response.ok) {
           console.error(`API Error: ${response.status} - ${responseText}`);
+          console.error("[BruniReporter] Failed auth diagnostics:", {
+            status: response.status,
+            token: summarizeToken(this.token),
+          });
           throw new Error(
             `Failed to send multi-page report: ${response.status} - ${responseText}`
           );


### PR DESCRIPTION
## Summary
- add sanitized `BRUNI_TOKEN` diagnostics at the MCP boundary before report uploads
- log auth-related token shape details in `BruniReporter` during initialization, upload attempts, and failed responses
- help debug missing reports without exposing the full token value

## Testing
- `npm test -- tests/unit/test_reporter.test.ts`
- `npm test -- tests/unit/test_mcp_server.test.ts`